### PR TITLE
Refactor constants imports

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,7 @@ from ui.themes.style_config import (
     TYPOGRAPHY,
     SPACING,
 )
+from config.settings import DEFAULT_ICONS, REQUIRED_INTERNAL_COLUMNS
 
 # Add project root to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -56,20 +57,7 @@ print("📊 Initializing comprehensive integrated system...")
 # VERSION 6.0 - ENHANCED IMPORTS WITH COMPLETE FALLBACK SUPPORT
 # ============================================================================
 
-# Core constants (always needed)
-DEFAULT_ICONS = {
-    'upload_default': '/assets/upload_file_csv_icon.png',
-    'upload_success': '/assets/upload_file_csv_icon_success.png',
-    'upload_fail': '/assets/upload_file_csv_icon_fail.png',
-    'main_logo': '/assets/logo_white.png'
-}
-
-REQUIRED_INTERNAL_COLUMNS = {
-    'Timestamp': 'Timestamp (Event Time)',
-    'UserID': 'UserID (Person Identifier)',
-    'DoorID': 'DoorID (Device Name)',
-    'EventType': 'EventType (Access Result)'
-}
+# Core constants imported from unified settings
 
 # Enhanced component availability tracking
 components_available = {

--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -8,29 +8,8 @@ All callbacks are handled by unified handler in app.py
 from dash import html, dcc
 import dash_cytoscape as cyto
 from ui.components.classification import create_classification_component
-
-# Fallback colors if theme not available
-COLORS = {
-    'primary': '#1B2A47',
-    'accent': '#2196F3',
-    'success': '#2DBE6C',
-    'warning': '#FFB020',
-    'critical': '#E02020',
-    'background': '#0F1419',
-    'surface': '#1A2332',
-    'border': '#2D3748',
-    'text_primary': '#F7FAFC',
-    'text_secondary': '#E2E8F0',
-    'text_tertiary': '#A0AEC0',
-}
-
-# Fallback constants
-REQUIRED_INTERNAL_COLUMNS = {
-    'Timestamp': 'Timestamp (Event Time)',
-    'UserID': 'UserID (Person Identifier)',
-    'DoorID': 'DoorID (Device Name)',
-    'EventType': 'EventType (Access Result)'
-}
+from ui.themes.style_config import COLORS
+from config.settings import REQUIRED_INTERNAL_COLUMNS
 # Instantiate the reusable classification component for entrance verification
 classification_component = create_classification_component()
 


### PR DESCRIPTION
## Summary
- import `DEFAULT_ICONS` and `REQUIRED_INTERNAL_COLUMNS` from unified settings
- rely on theme constants for the main page layout

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684245b576fc8320a32f500b10debbfb