### PR TITLE
Fix constants import

### DIFF
--- a/ui/pages/main_page.py
+++ b/ui/pages/main_page.py
@@ -11,14 +11,7 @@ from ui.components.classification import create_classification_component
 
 from ui.themes.style_config import COLORS, TYPOGRAPHY
 from ui.themes.helpers import get_button_style, get_card_style
-
-# Fallback constants
-REQUIRED_INTERNAL_COLUMNS = {
-    'Timestamp': 'Timestamp (Event Time)',
-    'UserID': 'UserID (Person Identifier)',
-    'DoorID': 'DoorID (Device Name)',
-    'EventType': 'EventType (Access Result)'
-}
+from config.settings import DEFAULT_ICONS, REQUIRED_INTERNAL_COLUMNS
 
 # Instantiate the reusable classification component for entrance verification
 classification_component = create_classification_component()


### PR DESCRIPTION
## Summary
- remove fallback required column mapping
- import settings constants directly in `main_page.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684249ae7c4c832099b87efa5a498728