### PR TITLE
Replace print with logger in settings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,9 @@ Replaces all other config files
 from dataclasses import dataclass, field
 from typing import Dict, List, Any, Optional
 import os
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 # ============================================================================
 # CONSTANTS - SINGLE SOURCE OF TRUTH
@@ -214,4 +217,7 @@ __all__ = [
     'settings'
 ]
 
-print(f"🔧 Unified settings loaded: {len(REQUIRED_INTERNAL_COLUMNS)} required columns")
+logger.info(
+    "🔧 Unified settings loaded: %d required columns",
+    len(REQUIRED_INTERNAL_COLUMNS),
+)


### PR DESCRIPTION
## Summary
- initialize a logger in `config/settings.py`
- replace the settings print statement with `logger.info`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684249c179308320bfd10db4545af78d